### PR TITLE
Numerous OS and Puppet support improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,13 +52,19 @@ jobs:
       matrix:
         set:
           - "centos-7"
+          - "centos-8"
           - "debian-9"
+          - "debian-10"
           - "ubuntu-1604"
           - "ubuntu-1804"
+          - "ubuntu-2004"
         puppet:
           - "puppet5"
           - "puppet6"
           - "puppet7"
+        exclude:
+          - set: "ubuntu-2004"
+            puppet: "puppet5"
     env:
       BUNDLE_WITHOUT: development:release
       BEAKER_debug: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -3,16 +3,16 @@
   acceptance_matrix:
     set:
       - centos-7
-      - '---centos-8'
+      - centos-8
       - debian-9
+      - debian-10
       - ubuntu-1604
       - ubuntu-1804
-    puppet:
-      - puppet5
-      - puppet6
+      - ubuntu-2004
+  acceptance_excludes:
+    - set: ubuntu-2004
+      puppet: puppet5
 .gitlab-ci.yml:
   delete: true
 appveyor.yml:
-  delete: true
-spec/acceptance/nodesets/debian-10.yml:
   delete: true

--- a/metadata.json
+++ b/metadata.json
@@ -17,58 +17,59 @@
       "version_requirement": ">= 4.0.0 <7.0.0"
     },
     {
-      "name": "stahnma/epel",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "name": "puppet/epel",
+      "version_requirement": ">= 3.0.0 <4.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ],
   "tags": [

--- a/spec/acceptance/nodesets/centos-8.yml
+++ b/spec/acceptance/nodesets/centos-8.yml
@@ -1,0 +1,26 @@
+HOSTS:
+  centos-8:
+    roles:
+      - agent
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: centos:8
+    docker_preserve_image: true
+    docker_cmd:
+      - '/usr/sbin/init'
+    docker_image_commands:
+      - 'yum install -y dnf-utils'
+      - 'dnf config-manager --set-enabled powertools'
+      - 'yum install -y wget which cronie iproute initscripts langpacks-en glibc-all-langpacks'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'clustershell-el8'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]
+

--- a/spec/acceptance/nodesets/debian-10.yml
+++ b/spec/acceptance/nodesets/debian-10.yml
@@ -1,0 +1,28 @@
+HOSTS:
+  debian10:
+    roles:
+      - agent
+    platform: debian-10-amd64
+    hypervisor: docker
+    image: debian:10
+    docker_preserve_image: true
+    docker_cmd:
+      - '/sbin/init'
+    docker_image_commands:
+      - 'apt-get install -y wget net-tools systemd-sysv locales apt-transport-https ca-certificates'
+      - 'echo "LC_ALL=en_US.UTF-8" >> /etc/environment'
+      - 'echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen'
+      - 'echo "LANG=en_US.UTF-8" > /etc/locale.conf'
+      - 'locale-gen en_US.UTF-8'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'clustershell-debian10'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]
+

--- a/spec/acceptance/nodesets/ubuntu-2004.yml
+++ b/spec/acceptance/nodesets/ubuntu-2004.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  ubuntu2004:
+    roles:
+      - agent
+    platform: ubuntu-20.04-amd64
+    hypervisor : docker
+    image: ubuntu:20.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
+      - 'apt-get install -y wget net-tools locales apt-transport-https ca-certificates'
+      - 'locale-gen en_US.UTF-8'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'clustershell-ubuntu2004'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]
+


### PR DESCRIPTION
Add OS support:
* RedHat/CentOS 8
* Debian 10
* Ubuntu 20.04

Drop OS support:
* RedHat/CentOS 6
* Debian 8

Support Puppet 7

Use puppet/epel module for EPEL dependency